### PR TITLE
Create secret-scanning-check.yml

### DIFF
--- a/.github/workflows/secret-scanning-check.yml
+++ b/.github/workflows/secret-scanning-check.yml
@@ -1,0 +1,31 @@
+name: Secret Scanning Status Check
+permissions:
+  contents: read
+  pull-requests: write
+
+on:
+  # workflow_dispatch:
+  pull_request:
+    types: [opened, reopened]
+    
+jobs:
+  Secret-Scanning-Check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Install jq
+        run: sudo apt-get install jq
+
+      - name: Run Secret Scanning Alert Check
+        id: secrets_check
+        run: |
+          response=$(curl -L \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ secrets.APP_TOKEN }}" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/${{ github.repository }}/secret-scanning/alerts)
+          echo "$response" | jq -r '.[] | select(.state!="resolved")' > state.json
+          if [ -s state.json ]; then
+            echo "::error file=state.json,line=1,col=1::Unresolved secret scanning alerts detected"
+            exit 1
+          fi
+        shell: bash


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automatically check for unresolved secret scanning alerts in pull requests. The workflow is triggered when a pull request is opened or reopened.